### PR TITLE
refactor: improve Notion renderer robustness

### DIFF
--- a/src/components/notion/NotionRenderer.tsx
+++ b/src/components/notion/NotionRenderer.tsx
@@ -78,17 +78,19 @@ function RendererWithChildren({block, order}: {
     order: number
 }) {
     let childrenOrder = 0
-    return <Renderer block={block} order={order}>
-        {block.has_children && block.children.map((block) => {
-            if (block.type === 'numbered_list_item') {
-                childrenOrder++
-            } else if (block.type.startsWith('heading_')) {
-                childrenOrder = 0
-            }
+    return (
+        <Renderer block={block} order={order}>
+            {block.children?.map((child) => {
+                if (child.type === 'numbered_list_item') {
+                    childrenOrder++
+                } else if (child.type.startsWith('heading_')) {
+                    childrenOrder = 0
+                }
 
-            return <RendererWithChildren key={block.id} block={block} order={childrenOrder}/>
-        })}
-    </Renderer>
+                return <RendererWithChildren key={child.id} block={child} order={childrenOrder} />
+            })}
+        </Renderer>
+    )
 }
 
 export default function NotionRenderer({blocks}: {
@@ -96,18 +98,18 @@ export default function NotionRenderer({blocks}: {
 }) {
     let order = 0
     return (
-        <main>
+        <>
             {blocks.map((block) => {
                 if (block.type === 'numbered_list_item') {
                     order++
                 } else if (block.type.startsWith('heading_')) {
                     order = 0
                 }
-                
+
                 return (
                     <RendererWithChildren key={block.id} block={block} order={order} />
                 )
             })}
-        </main>
+        </>
     )
 }

--- a/src/components/notion/blocks/ColumnList.tsx
+++ b/src/components/notion/blocks/ColumnList.tsx
@@ -8,10 +8,14 @@ export default function ColumnList({block, children}: PropsWithChildren<{
     if ('column_list' !== block.type) {
         return null
     }
-    const col = block.has_children ? block.children.length : 1
-    return <Block>
-        <div className="grid gap-x-3" style={{
-            gridTemplateColumns: `repeat(${col}, minmax(0, 1fr))`
-        }}>{children}</div>
-    </Block>
+    const col = block.children?.length ?? 1
+    return (
+        <Block>
+            <div className="grid gap-x-3" style={{
+                gridTemplateColumns: `repeat(${col}, minmax(0, 1fr))`
+            }}>
+                {children}
+            </div>
+        </Block>
+    )
 }

--- a/src/components/notion/blocks/Paragraph.tsx
+++ b/src/components/notion/blocks/Paragraph.tsx
@@ -11,6 +11,8 @@ export default function Paragraph({block}: PropsWithChildren<{
     }
     const paragraph = block.paragraph
     return (
-        <InlineBlock color={paragraph.color}>{<RichText rich_text={paragraph.rich_text}/>}</InlineBlock>
+        <InlineBlock color={paragraph.color}>
+            <RichText rich_text={paragraph.rich_text} />
+        </InlineBlock>
     )
 }

--- a/src/components/notion/blocks/Video.tsx
+++ b/src/components/notion/blocks/Video.tsx
@@ -12,12 +12,16 @@ export default function Video({block}: PropsWithChildren<{
     }
     const video = block.video
     const url = video.type === 'external' ? video.external.url : video.file.url
-    return <Block>
-        <div className="max-w-full w-fit mx-auto">
-            <video src={url} controls></video>
-            <InlineBlock className="text-neutral-500 text-sm">
-                <RichText rich_text={video.caption}/>
-            </InlineBlock>
-        </div>
-    </Block>
+    return (
+        <Block>
+            <div className="max-w-full w-fit mx-auto">
+                <video src={url} controls></video>
+                {video.caption.length > 0 && (
+                    <InlineBlock className="text-neutral-500 text-sm">
+                        <RichText rich_text={video.caption} />
+                    </InlineBlock>
+                )}
+            </div>
+        </Block>
+    )
 }


### PR DESCRIPTION
## Summary
- guard child rendering with optional chaining and clearer variable names
- remove nested `<main>` in Notion renderer to prevent invalid DOM structure
- streamline Notion block components for cleaner JSX and safer column calculation

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6896aa6eb208832b8bf9a3eab5d6f227