### PR TITLE
refactor: clean up components

### DIFF
--- a/src/components/LoadMoreIndicator.tsx
+++ b/src/components/LoadMoreIndicator.tsx
@@ -1,13 +1,15 @@
 'use client'
 
 import {useInView} from 'react-intersection-observer'
-import type {PropsWithChildren, FC} from 'react'
+import type {PropsWithChildren} from 'react'
 import Loading from '@/components/Loading'
 
-export const LoadMoreIndicator: FC<PropsWithChildren<{
-    className?: string,
+interface LoadMoreIndicatorProps extends PropsWithChildren {
+    className?: string
     onLoading: () => void
-}>> = ({ className, children, onLoading }) => {
+}
+
+export function LoadMoreIndicator({ className, children, onLoading }: LoadMoreIndicatorProps) {
     const { ref } = useInView({
         rootMargin: '1px',
         onChange(inView) {

--- a/src/components/MorePosts.tsx
+++ b/src/components/MorePosts.tsx
@@ -32,7 +32,7 @@ export default function MorePosts() {
                     <PostItem key={post.id} post={post} />
                 ))
             })}
-            {hasNextPage && <LoadMoreIndicator onLoading={() => fetchNextPage()} />}
+            {hasNextPage && <LoadMoreIndicator onLoading={fetchNextPage} />}
         </div>
     )
 }

--- a/src/components/common/Image.tsx
+++ b/src/components/common/Image.tsx
@@ -8,11 +8,7 @@ interface CamoImageProps {
 }
 
 export function CamoImage({ src, alt, className, loading }: CamoImageProps) {
-    if (void 0 === src) {
-        return <img src={src} alt={alt} className={className} loading={loading}></img>
-    }
-
-    const camoUrl = generateCamoUrl(src)
+    const camoUrl = src ? generateCamoUrl(src) : src
 
     return (
         <img src={camoUrl} alt={alt} className={className} loading={loading}></img>

--- a/src/components/ui/mermaid/MermaidRender.tsx
+++ b/src/components/ui/mermaid/MermaidRender.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react'
-import { useId, useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import mermaid from 'mermaid'
 import styles from './Mermaid.module.css'
 


### PR DESCRIPTION
## Summary
- simplify image wrapper by generating camo URL conditionally
- convert LoadMoreIndicator to function component without React.FC
- remove unused import in MermaidRender
- pass query `fetchNextPage` directly to LoadMoreIndicator

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689d4985073c832bab75107acca315e8